### PR TITLE
AI fixes on RV

### DIFF
--- a/OpenRA.Mods.RA2/Traits/BotModules/PowerDownBotModuleRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/PowerDownBotModuleRV.cs
@@ -1,0 +1,153 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules
+{
+	[Desc("Manages AI powerdown.")]
+	public class PowerDownBotModuleRVInfo : ConditionalTraitInfo
+	{
+		[Desc("Delay (in ticks) between toggling powerdown")]
+		public readonly int Interval = 150;
+
+		public override object Create(ActorInitializer init) { return new PowerDownBotModuleRV(init.Self, this); }
+	}
+
+	public class PowerDownBotModuleRV : ConditionalTrait<PowerDownBotModuleRVInfo>, IBotTick
+	{
+		readonly World world;
+		readonly Player player;
+		PowerManager playerPower;
+		int toggleTick;
+		readonly Func<Actor, bool> isToggledBuildingsValid;
+		List<BuildingPowerWrapper> toggledBuildings;
+
+		class BuildingPowerWrapper
+		{
+			public int PowerChanging;
+			public Actor Actor;
+
+			public BuildingPowerWrapper(Actor a, int p)
+			{
+				Actor = a;
+				PowerChanging = p;
+			}
+		}
+
+		public PowerDownBotModuleRV(Actor self, PowerDownBotModuleRVInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			toggledBuildings = new List<BuildingPowerWrapper>();
+			isToggledBuildingsValid = a => a.Owner == self.Owner && !a.IsDead && a.IsInWorld && GetTogglePowerChanging(a) < 0;
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			playerPower = self.TraitOrDefault<PowerManager>();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			toggleTick = world.LocalRandom.Next(0, Info.Interval);
+			toggledBuildings = new List<BuildingPowerWrapper>();
+		}
+
+		int GetTogglePowerChanging(Actor a)
+		{
+			var powerChangingIfToggled = 0;
+			var powerTarit = a.TraitsImplementing<Power>().Where(t => !t.IsTraitDisabled).ToArray();
+			var powerMulTrait = a.TraitsImplementing<PowerMultiplier>().ToArray();
+			if (powerTarit.Any())
+			{
+				powerChangingIfToggled = powerTarit.Sum(p => p.Info.Amount) * (powerMulTrait.Sum(p => p.Info.Modifier) - 100) / 100;
+				if (powerMulTrait.Where(t => !t.IsTraitDisabled).Any())
+					powerChangingIfToggled = -powerChangingIfToggled;
+			}
+
+			return powerChangingIfToggled;
+		}
+
+		IEnumerable<Actor> GetToggleableBuildings(IBot bot)
+		{
+			var toggleable = bot.Player.World.ActorsHavingTrait<ToggleConditionOnOrder>(t => !t.IsTraitDisabled && !t.IsTraitPaused)
+				.Where(a => a != null && !a.IsDead && a.Owner == player && a.Info.HasTraitInfo<PowerInfo>() && a.Info.HasTraitInfo<PowerMultiplierInfo>() && a.Info.HasTraitInfo<BuildingInfo>());
+
+			return toggleable;
+		}
+
+		IEnumerable<BuildingPowerWrapper> GetOnlineBuildings(IBot bot)
+		{
+			List<BuildingPowerWrapper> toggleableBuilding = new List<BuildingPowerWrapper>();
+
+			foreach (var a in GetToggleableBuildings(bot))
+			{
+				var powerChanging = GetTogglePowerChanging(a);
+				if (powerChanging > 0)
+					toggleableBuilding.Add(new BuildingPowerWrapper(a, powerChanging));
+			}
+
+			return toggleableBuilding.OrderBy(bpw => bpw.PowerChanging);
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			if (toggleTick > 0 || playerPower == null)
+			{
+				toggleTick--;
+				return;
+			}
+
+			var power = playerPower.ExcessPower;
+			toggledBuildings = toggledBuildings.Where(bpw => isToggledBuildingsValid(bpw.Actor)).OrderByDescending(bpw => bpw.PowerChanging).ToList();
+
+			// When there is extra power, check if AI can toggle on
+			if (power > 0)
+			{
+				foreach (var bpw in toggledBuildings)
+				{
+					if (power + bpw.PowerChanging < 0)
+						continue;
+
+					bot.QueueOrder(new Order("PowerDown", bpw.Actor, false));
+					power += bpw.PowerChanging;
+				}
+			}
+
+			// When there is no power, check if AI can toggle off
+			else if (power < 0)
+			{
+				var buildingsCanBeOff = GetOnlineBuildings(bot);
+				foreach (var bpw in buildingsCanBeOff)
+				{
+					if (power > 0)
+						break;
+
+					bot.QueueOrder(new Order("PowerDown", bpw.Actor, false));
+					toggledBuildings.Add(new BuildingPowerWrapper(bpw.Actor, -bpw.PowerChanging));
+					power += bpw.PowerChanging;
+				}
+			}
+
+			toggleTick = Info.Interval;
+		}
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/SquadManagerBotModuleRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/SquadManagerBotModuleRV.cs
@@ -1,0 +1,457 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.RV.Traits.BotModules.Squads;
+using OpenRA.Primitives;
+using OpenRA.Support;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules
+{
+	[Desc("Manages AI squads.")]
+	public class SquadManagerBotModuleRVInfo : ConditionalTraitInfo
+	{
+		[Desc("Actor types that are valid for naval squads.")]
+		public readonly HashSet<string> NavalUnitsTypes = new HashSet<string>();
+
+		[Desc("Actor types that should generally be excluded from attack squads.")]
+		public readonly HashSet<string> ExcludeFromSquadsTypes = new HashSet<string>();
+
+		[Desc("Actor types that are considered construction yards (base builders).")]
+		public readonly HashSet<string> ConstructionYardTypes = new HashSet<string>();
+
+		[Desc("Enemy building types around which to scan for targets for naval squads.")]
+		public readonly HashSet<string> NavalProductionTypes = new HashSet<string>();
+
+		[Desc("Minimum number of units AI must have before attacking.")]
+		public readonly int SquadSize = 8;
+
+		[Desc("Random number of up to this many units is added to squad size when creating an attack squad.")]
+		public readonly int SquadSizeRandomBonus = 30;
+
+		[Desc("Delay (in ticks) between giving out orders to units.")]
+		public readonly int AssignRolesInterval = 50;
+
+		[Desc("Delay (in ticks) between attempting rush attacks.")]
+		public readonly int RushInterval = 600;
+
+		[Desc("Delay (in ticks) between updating squads.")]
+		public readonly int AttackForceInterval = 75;
+
+		[Desc("Minimum delay (in ticks) between creating squads.")]
+		public readonly int MinimumAttackForceDelay = 0;
+
+		[Desc("Radius in cells around enemy BaseBuilder (Construction Yard) where AI scans for targets to rush.")]
+		public readonly int RushAttackScanRadius = 15;
+
+		[Desc("Radius in cells around the base that should be scanned for units to be protected.")]
+		public readonly int ProtectUnitScanRadius = 15;
+
+		[Desc("Maximum distance in cells from center of the base when checking for MCV deployment location.",
+			"Only applies if RestrictMCVDeploymentFallbackToBase is enabled and there's at least one construction yard.")]
+		public readonly int MaxBaseRadius = 20;
+
+		[Desc("Radius in cells that squads should scan for enemies around their position while idle.")]
+		public readonly int IdleScanRadius = 10;
+
+		[Desc("Radius in cells that squads should scan for danger around their position to make flee decisions.")]
+		public readonly int DangerScanRadius = 10;
+
+		[Desc("Radius in cells that attack squads should scan for enemies around their position when trying to attack.")]
+		public readonly int AttackScanRadius = 12;
+
+		[Desc("Radius in cells that protecting squads should scan for enemies around their position.")]
+		public readonly int ProtectionScanRadius = 8;
+
+		[Desc("Enemy target types to never target.")]
+		public readonly BitSet<TargetableType> IgnoredEnemyTargetTypes = default(BitSet<TargetableType>);
+
+		public override object Create(ActorInitializer init) { return new SquadManagerBotModuleRV(init.Self, this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			base.RulesetLoaded(rules, ai);
+			if (DangerScanRadius <= 0)
+				throw new YamlException("DangerScanRadius must be greater than zero.");
+		}
+	}
+
+	public class SquadManagerBotModuleRV : ConditionalTrait<SquadManagerBotModuleRVInfo>, IBotEnabled, IBotTick, IBotRespondToAttack, IBotPositionsUpdated, IGameSaveTraitData
+	{
+		public CPos GetRandomBaseCenter()
+		{
+			var randomConstructionYard = World.Actors.Where(a => a.Owner == Player &&
+				Info.ConstructionYardTypes.Contains(a.Info.Name))
+				.RandomOrDefault(World.LocalRandom);
+
+			return randomConstructionYard != null ? randomConstructionYard.Location : initialBaseCenter;
+		}
+
+		public readonly World World;
+		public readonly Player Player;
+
+		readonly Predicate<Actor> unitCannotBeOrdered;
+
+		public List<SquadRV> Squads = new List<SquadRV>();
+
+		IBot bot;
+		IBotPositionsUpdated[] notifyPositionsUpdated;
+		IBotNotifyIdleBaseUnits[] notifyIdleBaseUnits;
+
+		CPos initialBaseCenter;
+		List<Actor> unitsHangingAroundTheBase = new List<Actor>();
+
+		// Units that the bot already knows about. Any unit not on this list needs to be given a role.
+		List<Actor> activeUnits = new List<Actor>();
+
+		int rushTicks;
+		int assignRolesTicks;
+		int attackForceTicks;
+		int minAttackForceDelayTicks;
+
+		public SquadManagerBotModuleRV(Actor self, SquadManagerBotModuleRVInfo info)
+			: base(info)
+		{
+			World = self.World;
+			Player = self.Owner;
+
+			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld;
+		}
+
+		// Use for proactive targeting.
+		public bool IsPreferredEnemyUnit(Actor a)
+		{
+			if (a == null || a.IsDead || Player.Stances[a.Owner] != Stance.Enemy || a.Info.HasTraitInfo<HuskInfo>())
+				return false;
+
+			var targetTypes = a.GetEnabledTargetTypes();
+			return !targetTypes.IsEmpty && !targetTypes.Overlaps(Info.IgnoredEnemyTargetTypes);
+		}
+
+		public bool IsNotHiddenUnit(Actor a)
+		{
+			var hasModifier = false;
+			var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+			foreach (var v in visModifiers)
+			{
+				if (v.IsVisible(a, Player))
+					return true;
+
+				hasModifier = true;
+			}
+
+			return !hasModifier;
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			notifyPositionsUpdated = Player.PlayerActor.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+			notifyIdleBaseUnits = Player.PlayerActor.TraitsImplementing<IBotNotifyIdleBaseUnits>().ToArray();
+
+			// Avoid all AIs trying to rush in the same tick, randomize their initial rush a little.
+			var smallFractionOfRushInterval = Info.RushInterval / 20;
+			rushTicks = World.LocalRandom.Next(Info.RushInterval - smallFractionOfRushInterval, Info.RushInterval + smallFractionOfRushInterval);
+
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			assignRolesTicks = World.LocalRandom.Next(0, Info.AssignRolesInterval);
+			attackForceTicks = World.LocalRandom.Next(0, Info.AttackForceInterval);
+			minAttackForceDelayTicks = World.LocalRandom.Next(0, Info.MinimumAttackForceDelay);
+		}
+
+		void IBotEnabled.BotEnabled(IBot bot)
+		{
+			this.bot = bot;
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			AssignRolesToIdleUnits(bot);
+		}
+
+		internal Actor FindClosestEnemy(WPos pos)
+		{
+			var units = World.Actors.Where(IsPreferredEnemyUnit);
+			return units.Where(IsNotHiddenUnit).ClosestTo(pos) ?? units.ClosestTo(pos);
+		}
+
+		internal Actor FindClosestEnemy(WPos pos, WDist radius)
+		{
+			return World.FindActorsInCircle(pos, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a)).ClosestTo(pos);
+		}
+
+		void CleanSquads()
+		{
+			Squads.RemoveAll(s => !s.IsValid);
+			foreach (var s in Squads)
+				s.Units.RemoveAll(unitCannotBeOrdered);
+		}
+
+		// HACK: Use of this function requires that there is one squad of this type.
+		SquadRV GetSquadOfType(SquadTypeRV type)
+		{
+			return Squads.FirstOrDefault(s => s.Type == type);
+		}
+
+		SquadRV RegisterNewSquad(IBot bot, SquadTypeRV type, Actor target = null)
+		{
+			var ret = new SquadRV(bot, this, type, target);
+			Squads.Add(ret);
+			return ret;
+		}
+
+		void AssignRolesToIdleUnits(IBot bot)
+		{
+			CleanSquads();
+
+			activeUnits.RemoveAll(unitCannotBeOrdered);
+			unitsHangingAroundTheBase.RemoveAll(unitCannotBeOrdered);
+			foreach (var n in notifyIdleBaseUnits)
+				n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
+
+			if (--rushTicks <= 0)
+			{
+				rushTicks = Info.RushInterval;
+				TryToRushAttack(bot);
+			}
+
+			if (--attackForceTicks <= 0)
+			{
+				attackForceTicks = Info.AttackForceInterval;
+				foreach (var s in Squads)
+					s.Update();
+			}
+
+			if (--assignRolesTicks <= 0)
+			{
+				assignRolesTicks = Info.AssignRolesInterval;
+				FindNewUnits(bot);
+			}
+
+			if (--minAttackForceDelayTicks <= 0)
+			{
+				minAttackForceDelayTicks = Info.MinimumAttackForceDelay;
+				CreateAttackForce(bot);
+			}
+		}
+
+		void FindNewUnits(IBot bot)
+		{
+			var newUnits = World.ActorsHavingTrait<IPositionable>()
+				.Where(a => a.Owner == Player &&
+					!Info.ExcludeFromSquadsTypes.Contains(a.Info.Name) &&
+					!activeUnits.Contains(a));
+
+			foreach (var a in newUnits)
+			{
+				unitsHangingAroundTheBase.Add(a);
+
+				if (a.Info.HasTraitInfo<AircraftInfo>() && a.Info.HasTraitInfo<AttackBaseInfo>())
+				{
+					var air = GetSquadOfType(SquadTypeRV.Air);
+					if (air == null)
+						air = RegisterNewSquad(bot, SquadTypeRV.Air);
+
+					air.Units.Add(a);
+				}
+				else if (Info.NavalUnitsTypes.Contains(a.Info.Name))
+				{
+					var ships = GetSquadOfType(SquadTypeRV.Naval);
+					if (ships == null)
+						ships = RegisterNewSquad(bot, SquadTypeRV.Naval);
+
+					ships.Units.Add(a);
+				}
+
+				activeUnits.Add(a);
+			}
+
+			// Notifying here rather than inside the loop, should be fine and saves a bunch of notification calls
+			foreach (var n in notifyIdleBaseUnits)
+				n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
+		}
+
+		void CreateAttackForce(IBot bot)
+		{
+			// Create an attack force when we have enough units around our base.
+			// (don't bother leaving any behind for defense)
+			var randomizedSquadSize = Info.SquadSize + World.LocalRandom.Next(Info.SquadSizeRandomBonus);
+
+			if (unitsHangingAroundTheBase.Count >= randomizedSquadSize)
+			{
+				var attackForce = RegisterNewSquad(bot, SquadTypeRV.Assault);
+
+				foreach (var a in unitsHangingAroundTheBase)
+					if (!a.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(a.Info.Name))
+						attackForce.Units.Add(a);
+
+				unitsHangingAroundTheBase.Clear();
+				foreach (var n in notifyIdleBaseUnits)
+					n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
+			}
+		}
+
+		void TryToRushAttack(IBot bot)
+		{
+			var allEnemyBaseBuilder = AIUtils.FindEnemiesByCommonName(Info.ConstructionYardTypes, Player);
+
+			// TODO: This should use common names & ExcludeFromSquads instead of hardcoding TraitInfo checks
+			var ownUnits = activeUnits
+				.Where(unit => unit.IsIdle && unit.Info.HasTraitInfo<AttackBaseInfo>()
+					&& !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name) && !unit.Info.HasTraitInfo<HarvesterInfo>()).ToList();
+
+			if (!allEnemyBaseBuilder.Any() || ownUnits.Count < Info.SquadSize)
+				return;
+
+			foreach (var b in allEnemyBaseBuilder)
+			{
+				// Don't rush enemy aircraft!
+				var enemies = World.FindActorsInCircle(b.CenterPosition, WDist.FromCells(Info.RushAttackScanRadius))
+					.Where(unit => IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name)).ToList();
+
+				if (AttackOrFleeFuzzyRV.Rush.CanAttack(ownUnits, enemies))
+				{
+					var target = enemies.Any() ? enemies.Random(World.LocalRandom) : b;
+					var rush = GetSquadOfType(SquadTypeRV.Rush);
+					if (rush == null)
+						rush = RegisterNewSquad(bot, SquadTypeRV.Rush, target);
+
+					foreach (var a3 in ownUnits)
+						rush.Units.Add(a3);
+
+					return;
+				}
+			}
+		}
+
+		void ProtectOwn(IBot bot, Actor attacker)
+		{
+			var protectSq = GetSquadOfType(SquadTypeRV.Protection);
+			if (protectSq == null)
+				protectSq = RegisterNewSquad(bot, SquadTypeRV.Protection, attacker);
+
+			if (!protectSq.IsTargetValid)
+				protectSq.TargetActor = attacker;
+
+			if (!protectSq.IsValid)
+			{
+				var ownUnits = World.FindActorsInCircle(World.Map.CenterOfCell(GetRandomBaseCenter()), WDist.FromCells(Info.ProtectUnitScanRadius))
+					.Where(unit => unit.Owner == Player && !unit.Info.HasTraitInfo<BuildingInfo>() && !unit.Info.HasTraitInfo<HarvesterInfo>()
+						&& unit.Info.HasTraitInfo<AttackBaseInfo>());
+
+				foreach (var a in ownUnits)
+					protectSq.Units.Add(a);
+			}
+		}
+
+		void IBotPositionsUpdated.UpdatedBaseCenter(CPos newLocation)
+		{
+			initialBaseCenter = newLocation;
+		}
+
+		void IBotPositionsUpdated.UpdatedDefenseCenter(CPos newLocation) { }
+
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
+		{
+			if (!IsPreferredEnemyUnit(e.Attacker))
+				return;
+
+			// Protected priority assets, MCVs, harvesters and buildings
+			// TODO: Use *CommonNames, instead of hard-coding trait(info)s.
+			if (self.Info.HasTraitInfo<HarvesterInfo>() || self.Info.HasTraitInfo<BuildingInfo>() || self.Info.HasTraitInfo<BaseBuildingInfo>())
+			{
+				foreach (var n in notifyPositionsUpdated)
+					n.UpdatedDefenseCenter(e.Attacker.Location);
+
+				ProtectOwn(bot, e.Attacker);
+			}
+		}
+
+		List<MiniYamlNode> IGameSaveTraitData.IssueTraitData(Actor self)
+		{
+			if (IsTraitDisabled)
+				return null;
+
+			return new List<MiniYamlNode>()
+			{
+				new MiniYamlNode("Squads", "", Squads.Select(s => new MiniYamlNode("Squad", s.Serialize())).ToList()),
+				new MiniYamlNode("InitialBaseCenter", FieldSaver.FormatValue(initialBaseCenter)),
+				new MiniYamlNode("UnitsHangingAroundTheBase", FieldSaver.FormatValue(unitsHangingAroundTheBase
+					.Where(a => !unitCannotBeOrdered(a))
+					.Select(a => a.ActorID)
+					.ToArray())),
+				new MiniYamlNode("ActiveUnits", FieldSaver.FormatValue(activeUnits
+					.Where(a => !unitCannotBeOrdered(a))
+					.Select(a => a.ActorID)
+					.ToArray())),
+				new MiniYamlNode("RushTicks", FieldSaver.FormatValue(rushTicks)),
+				new MiniYamlNode("AssignRolesTicks", FieldSaver.FormatValue(assignRolesTicks)),
+				new MiniYamlNode("AttackForceTicks", FieldSaver.FormatValue(attackForceTicks)),
+				new MiniYamlNode("MinAttackForceDelayTicks", FieldSaver.FormatValue(minAttackForceDelayTicks)),
+			};
+		}
+
+		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		{
+			if (self.World.IsReplay)
+				return;
+
+			var initialBaseCenterNode = data.FirstOrDefault(n => n.Key == "InitialBaseCenter");
+			if (initialBaseCenterNode != null)
+				initialBaseCenter = FieldLoader.GetValue<CPos>("InitialBaseCenter", initialBaseCenterNode.Value.Value);
+
+			var unitsHangingAroundTheBaseNode = data.FirstOrDefault(n => n.Key == "UnitsHangingAroundTheBase");
+			if (unitsHangingAroundTheBaseNode != null)
+			{
+				unitsHangingAroundTheBase.Clear();
+				unitsHangingAroundTheBase.AddRange(FieldLoader.GetValue<uint[]>("UnitsHangingAroundTheBase", unitsHangingAroundTheBaseNode.Value.Value)
+					.Select(a => self.World.GetActorById(a)).Where(a => a != null));
+			}
+
+			var activeUnitsNode = data.FirstOrDefault(n => n.Key == "ActiveUnits");
+			if (activeUnitsNode != null)
+			{
+				activeUnits.Clear();
+				activeUnits.AddRange(FieldLoader.GetValue<uint[]>("ActiveUnits", activeUnitsNode.Value.Value)
+					.Select(a => self.World.GetActorById(a)).Where(a => a != null));
+			}
+
+			var rushTicksNode = data.FirstOrDefault(n => n.Key == "RushTicks");
+			if (rushTicksNode != null)
+				rushTicks = FieldLoader.GetValue<int>("RushTicks", rushTicksNode.Value.Value);
+
+			var assignRolesTicksNode = data.FirstOrDefault(n => n.Key == "AssignRolesTicks");
+			if (assignRolesTicksNode != null)
+				assignRolesTicks = FieldLoader.GetValue<int>("AssignRolesTicks", assignRolesTicksNode.Value.Value);
+
+			var attackForceTicksNode = data.FirstOrDefault(n => n.Key == "AttackForceTicks");
+			if (attackForceTicksNode != null)
+				attackForceTicks = FieldLoader.GetValue<int>("AttackForceTicks", attackForceTicksNode.Value.Value);
+
+			var minAttackForceDelayTicksNode = data.FirstOrDefault(n => n.Key == "MinAttackForceDelayTicks");
+			if (minAttackForceDelayTicksNode != null)
+				minAttackForceDelayTicks = FieldLoader.GetValue<int>("MinAttackForceDelayTicks", minAttackForceDelayTicksNode.Value.Value);
+
+			var squadsNode = data.FirstOrDefault(n => n.Key == "Squads");
+			if (squadsNode != null)
+			{
+				Squads.Clear();
+				foreach (var n in squadsNode.Value.Nodes)
+					Squads.Add(SquadRV.Deserialize(bot, this, n.Value));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/AttackOrFleeFuzzyRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/AttackOrFleeFuzzyRV.cs
@@ -1,0 +1,276 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AI.Fuzzy.Library;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Warheads;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	sealed class AttackOrFleeFuzzyRV
+	{
+		static readonly string[] DefaultRulesNormalOwnHealth = new[]
+		{
+			"if ((OwnHealth is Normal) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and ((RelativeAttackPower is Weak) or (RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
+			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Attack"
+		};
+
+		static readonly string[] DefaultRulesInjuredOwnHealth = new[]
+		{
+			"if ((OwnHealth is Injured) " +
+			"and (EnemyHealth is NearDead) " +
+			"and ((RelativeAttackPower is Weak) or (RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
+			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Attack",
+
+			"if ((OwnHealth is Injured) " +
+			"and ((EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and ((RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
+			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Attack",
+
+			"if ((OwnHealth is Injured) " +
+			"and ((EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and (RelativeAttackPower is Weak) " +
+			"and (RelativeSpeed is Slow)) " +
+			"then AttackOrFlee is Attack",
+
+			"if ((OwnHealth is Injured) " +
+			"and ((EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and (RelativeAttackPower is Weak) " +
+			"and ((RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Flee",
+
+			"if ((OwnHealth is Injured) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and ((RelativeAttackPower is Weak) or (RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
+			"and (RelativeSpeed is Slow)) " +
+			"then AttackOrFlee is Attack"
+		};
+
+		static readonly string[] DefaultRulesNearDeadOwnHealth = new[]
+		{
+			"if ((OwnHealth is NearDead) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured)) " +
+			"and ((RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
+			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal))) " +
+			"then AttackOrFlee is Attack",
+
+			"if ((OwnHealth is NearDead) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured)) " +
+			"and (RelativeAttackPower is Weak) " +
+			"and ((RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Flee",
+
+			"if ((OwnHealth is NearDead) " +
+			"and (EnemyHealth is Normal) " +
+			"and (RelativeAttackPower is Weak) " +
+			"and ((RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Flee",
+
+			"if (OwnHealth is NearDead) " +
+			"and (EnemyHealth is Normal) " +
+			"and ((RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
+			"and (RelativeSpeed is Fast) " +
+			"then AttackOrFlee is Flee",
+
+			"if (OwnHealth is NearDead) " +
+			"and (EnemyHealth is Injured) " +
+			"and (RelativeAttackPower is Equal) " +
+			"and (RelativeSpeed is Fast) " +
+			"then AttackOrFlee is Flee"
+		};
+
+		public static readonly AttackOrFleeFuzzyRV Default = new AttackOrFleeFuzzyRV(null, null, null);
+		public static readonly AttackOrFleeFuzzyRV Rush = new AttackOrFleeFuzzyRV(new[]
+		{
+			"if ((OwnHealth is Normal) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and (RelativeAttackPower is Strong) " +
+			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Attack",
+
+			"if ((OwnHealth is Normal) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured) or (EnemyHealth is Normal)) " +
+			"and ((RelativeAttackPower is Weak) or (RelativeAttackPower is Equal)) " +
+			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
+			"then AttackOrFlee is Flee"
+		}, null, null);
+
+		readonly MamdaniFuzzySystem fuzzyEngine = new MamdaniFuzzySystem();
+
+		public AttackOrFleeFuzzyRV(
+			IEnumerable<string> rulesForNormalOwnHealth,
+			IEnumerable<string> rulesForInjuredOwnHealth,
+			IEnumerable<string> rulesForNeadDeadOwnHealth)
+		{
+			lock (fuzzyEngine)
+			{
+				var playerHealthFuzzy = new FuzzyVariable("OwnHealth", 0.0, 100.0);
+				playerHealthFuzzy.Terms.Add(new FuzzyTerm("NearDead", new TrapezoidMembershipFunction(0, 0, 20, 40)));
+				playerHealthFuzzy.Terms.Add(new FuzzyTerm("Injured", new TrapezoidMembershipFunction(30, 50, 50, 70)));
+				playerHealthFuzzy.Terms.Add(new FuzzyTerm("Normal", new TrapezoidMembershipFunction(50, 80, 100, 100)));
+				fuzzyEngine.Input.Add(playerHealthFuzzy);
+
+				var enemyHealthFuzzy = new FuzzyVariable("EnemyHealth", 0.0, 100.0);
+				enemyHealthFuzzy.Terms.Add(new FuzzyTerm("NearDead", new TrapezoidMembershipFunction(0, 0, 20, 40)));
+				enemyHealthFuzzy.Terms.Add(new FuzzyTerm("Injured", new TrapezoidMembershipFunction(30, 50, 50, 70)));
+				enemyHealthFuzzy.Terms.Add(new FuzzyTerm("Normal", new TrapezoidMembershipFunction(50, 80, 100, 100)));
+				fuzzyEngine.Input.Add(enemyHealthFuzzy);
+
+				var relativeAttackPowerFuzzy = new FuzzyVariable("RelativeAttackPower", 0.0, 1000.0);
+				relativeAttackPowerFuzzy.Terms.Add(new FuzzyTerm("Weak", new TrapezoidMembershipFunction(0, 0, 70, 90)));
+				relativeAttackPowerFuzzy.Terms.Add(new FuzzyTerm("Equal", new TrapezoidMembershipFunction(85, 100, 100, 115)));
+				relativeAttackPowerFuzzy.Terms.Add(new FuzzyTerm("Strong", new TrapezoidMembershipFunction(110, 150, 150, 1000)));
+				fuzzyEngine.Input.Add(relativeAttackPowerFuzzy);
+
+				var relativeSpeedFuzzy = new FuzzyVariable("RelativeSpeed", 0.0, 1000.0);
+				relativeSpeedFuzzy.Terms.Add(new FuzzyTerm("Slow", new TrapezoidMembershipFunction(0, 0, 70, 90)));
+				relativeSpeedFuzzy.Terms.Add(new FuzzyTerm("Equal", new TrapezoidMembershipFunction(85, 100, 100, 115)));
+				relativeSpeedFuzzy.Terms.Add(new FuzzyTerm("Fast", new TrapezoidMembershipFunction(110, 150, 150, 1000)));
+				fuzzyEngine.Input.Add(relativeSpeedFuzzy);
+
+				var attackOrFleeFuzzy = new FuzzyVariable("AttackOrFlee", 0.0, 50.0);
+				attackOrFleeFuzzy.Terms.Add(new FuzzyTerm("Attack", new TrapezoidMembershipFunction(0, 15, 15, 30)));
+				attackOrFleeFuzzy.Terms.Add(new FuzzyTerm("Flee", new TrapezoidMembershipFunction(25, 35, 35, 50)));
+				fuzzyEngine.Output.Add(attackOrFleeFuzzy);
+
+				foreach (var rule in rulesForNormalOwnHealth ?? DefaultRulesNormalOwnHealth)
+					AddFuzzyRule(rule);
+				foreach (var rule in rulesForInjuredOwnHealth ?? DefaultRulesInjuredOwnHealth)
+					AddFuzzyRule(rule);
+				foreach (var rule in rulesForNeadDeadOwnHealth ?? DefaultRulesNearDeadOwnHealth)
+					AddFuzzyRule(rule);
+			}
+		}
+
+		void AddFuzzyRule(string rule)
+		{
+			fuzzyEngine.Rules.Add(fuzzyEngine.ParseRule(rule));
+		}
+
+		public bool CanAttack(IEnumerable<Actor> ownUnits, IEnumerable<Actor> enemyUnits)
+		{
+			double attackChance;
+			var inputValues = new Dictionary<FuzzyVariable, double>();
+			lock (fuzzyEngine)
+			{
+				inputValues.Add(fuzzyEngine.InputByName("OwnHealth"), NormalizedHealth(ownUnits, 100));
+				inputValues.Add(fuzzyEngine.InputByName("EnemyHealth"), NormalizedHealth(enemyUnits, 100));
+				inputValues.Add(fuzzyEngine.InputByName("RelativeAttackPower"), RelativePower(ownUnits, enemyUnits));
+				inputValues.Add(fuzzyEngine.InputByName("RelativeSpeed"), RelativeSpeed(ownUnits, enemyUnits));
+
+				var result = fuzzyEngine.Calculate(inputValues);
+				attackChance = result[fuzzyEngine.OutputByName("AttackOrFlee")];
+			}
+
+			return !double.IsNaN(attackChance) && attackChance < 30.0;
+		}
+
+		static float NormalizedHealth(IEnumerable<Actor> actors, float normalizeByValue)
+		{
+			var sumOfMaxHp = 0;
+			var sumOfHp = 0;
+			foreach (var a in actors)
+			{
+				if (a.Info.HasTraitInfo<IHealthInfo>())
+				{
+					sumOfMaxHp += a.Trait<IHealth>().MaxHP;
+					sumOfHp += a.Trait<IHealth>().HP;
+				}
+			}
+
+			if (sumOfMaxHp == 0)
+				return 0.0f;
+
+			// Cast to long to avoid overflow when multiplying by the health
+			return (int)((long)sumOfHp * normalizeByValue / sumOfMaxHp);
+		}
+
+		static float RelativePower(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
+		{
+			return RelativeValue(own, enemy, 100, SumOfValues<AttackBaseInfo>, a =>
+			{
+				var sumOfDamage = 0;
+				var arms = a.TraitsImplementing<Armament>();
+				foreach (var arm in arms)
+				{
+					var burst = arm.Weapon.Burst;
+
+					// For simplicity's sake, we're only factoring in the first burst delay, as more than one burst delay is extremely rare.
+					// Additionally, clamping total delay to minimum of 1 (ReloadDelay: 0 is technically possible) and maximum of 200.
+					// High dmg/low ROF weapons shouldn't be rated too low as high dmg/shot can outweigh mere dps due to likelier 1-hit-kills.
+					// TODO: Revisit this at some point to replace the arbitrary cap with something smarter.
+					var totalReloadDelay = arm.Weapon.ReloadDelay + (arm.Weapon.BurstDelays[0] * (burst - 1)).Clamp(1, 200);
+					var damageWarheads = arm.Weapon.Warheads.OfType<DamageWarhead>();
+					foreach (var warhead in damageWarheads)
+						sumOfDamage += (warhead.Damage * burst / totalReloadDelay) * 100;
+				}
+
+				return sumOfDamage;
+			});
+		}
+
+		static float RelativeSpeed(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
+		{
+			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Info.TraitInfo<MobileInfo>().Speed);
+		}
+
+		static float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue,
+					Func<IEnumerable<Actor>, Func<Actor, int>, float> relativeFunc, Func<Actor, int> getValue)
+		{
+			if (!enemy.Any())
+				return 999.0f;
+
+			if (!own.Any())
+				return 0.0f;
+
+			var relative = (relativeFunc(own, getValue) / relativeFunc(enemy, getValue)) * normalizeByValue;
+			return relative.Clamp(0.0f, 999.0f);
+		}
+
+		static float SumOfValues<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfoInterface
+		{
+			var sum = 0;
+			foreach (var a in actors)
+				if (a.Info.HasTraitInfo<TTraitInfo>())
+					sum += getValue(a);
+
+			return sum;
+		}
+
+		static float Average<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfoInterface
+		{
+			var sum = 0;
+			var countActors = 0;
+			foreach (var a in actors)
+			{
+				if (a.Info.HasTraitInfo<TTraitInfo>())
+				{
+					sum += getValue(a);
+					countActors++;
+				}
+			}
+
+			if (countActors == 0)
+				return 0.0f;
+
+			return sum / countActors;
+		}
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/SquadRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/SquadRV.cs
@@ -1,0 +1,129 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Support;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	public enum SquadTypeRV { Assault, Air, Rush, Protection, Naval }
+
+	public class SquadRV
+	{
+		public List<Actor> Units = new List<Actor>();
+		public SquadTypeRV Type;
+
+		internal IBot Bot;
+		internal World World;
+		internal SquadManagerBotModuleRV SquadManager;
+		internal MersenneTwister Random;
+
+		internal Target Target;
+		internal StateMachineRV FuzzyStateMachine;
+
+		public SquadRV(IBot bot, SquadManagerBotModuleRV squadManager, SquadTypeRV type)
+			: this(bot, squadManager, type, null) { }
+
+		public SquadRV(IBot bot, SquadManagerBotModuleRV squadManager, SquadTypeRV type, Actor target)
+		{
+			Bot = bot;
+			SquadManager = squadManager;
+			World = bot.Player.PlayerActor.World;
+			Random = World.LocalRandom;
+			Type = type;
+			Target = Target.FromActor(target);
+			FuzzyStateMachine = new StateMachineRV();
+
+			switch (type)
+			{
+				case SquadTypeRV.Assault:
+				case SquadTypeRV.Rush:
+					FuzzyStateMachine.ChangeState(this, new GroundUnitsIdleStateRV(), true);
+					break;
+				case SquadTypeRV.Air:
+					FuzzyStateMachine.ChangeState(this, new AirIdleStateRV(), true);
+					break;
+				case SquadTypeRV.Protection:
+					FuzzyStateMachine.ChangeState(this, new UnitsForProtectionIdleStateRV(), true);
+					break;
+				case SquadTypeRV.Naval:
+					FuzzyStateMachine.ChangeState(this, new NavyUnitsIdleStateRV(), true);
+					break;
+			}
+		}
+
+		public void Update()
+		{
+			if (IsValid)
+				FuzzyStateMachine.Update(this);
+		}
+
+		public bool IsValid { get { return Units.Any(); } }
+
+		public Actor TargetActor
+		{
+			get { return Target.Actor; }
+			set { Target = Target.FromActor(value); }
+		}
+
+		public bool IsTargetValid
+		{
+			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.Info.HasTraitInfo<HuskInfo>(); }
+		}
+
+		public bool IsTargetVisible
+		{
+			get { return TargetActor.CanBeViewedByPlayer(Bot.Player); }
+		}
+
+		public WPos CenterPosition { get { return Units.Select(u => u.CenterPosition).Average(); } }
+
+		public MiniYaml Serialize()
+		{
+			var nodes = new MiniYaml("", new List<MiniYamlNode>()
+			{
+				new MiniYamlNode("Type", FieldSaver.FormatValue(Type)),
+				new MiniYamlNode("Units", FieldSaver.FormatValue(Units.Select(a => a.ActorID).ToArray())),
+			});
+
+			if (Target.Type == TargetType.Actor)
+				nodes.Nodes.Add(new MiniYamlNode("Target", FieldSaver.FormatValue(Target.Actor.ActorID)));
+
+			return nodes;
+		}
+
+		public static SquadRV Deserialize(IBot bot, SquadManagerBotModuleRV squadManager, MiniYaml yaml)
+		{
+			var type = SquadTypeRV.Rush;
+			Actor targetActor = null;
+
+			var typeNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Type");
+			if (typeNode != null)
+				type = FieldLoader.GetValue<SquadTypeRV>("Type", typeNode.Value.Value);
+
+			var targetNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Target");
+			if (targetNode != null)
+				targetActor = squadManager.World.GetActorById(FieldLoader.GetValue<uint>("ActiveUnits", targetNode.Value.Value));
+
+			var squad = new SquadRV(bot, squadManager, type, targetActor);
+
+			var unitsNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Units");
+			if (unitsNode != null)
+				squad.Units.AddRange(FieldLoader.GetValue<uint[]>("Units", unitsNode.Value.Value)
+					.Select(a => squadManager.World.GetActorById(a)));
+
+			return squad;
+		}
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/StateMachineRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/StateMachineRV.cs
@@ -1,0 +1,52 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	class StateMachineRV
+	{
+		IState currentState;
+		IState previousState;
+
+		public void Update(SquadRV squad)
+		{
+			if (currentState != null)
+				currentState.Tick(squad);
+		}
+
+		public void ChangeState(SquadRV squad, IState newState, bool rememberPrevious)
+		{
+			if (rememberPrevious)
+				previousState = currentState;
+
+			if (currentState != null)
+				currentState.Deactivate(squad);
+
+			if (newState != null)
+				currentState = newState;
+
+			if (currentState != null)
+				currentState.Activate(squad);
+		}
+
+		public void RevertToPreviousState(SquadRV squad, bool saveCurrentState)
+		{
+			ChangeState(squad, previousState, saveCurrentState);
+		}
+	}
+
+	interface IState
+	{
+		void Activate(SquadRV bot);
+		void Tick(SquadRV bot);
+		void Deactivate(SquadRV bot);
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/AirStatesRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/AirStatesRV.cs
@@ -1,0 +1,235 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	abstract class AirStateBaseRV : StateBaseRV
+	{
+		static readonly BitSet<TargetableType> AirTargetTypes = new BitSet<TargetableType>("Air");
+
+		protected static int CountAntiAirUnits(IEnumerable<Actor> units)
+		{
+			if (!units.Any())
+				return 0;
+
+			var missileUnitsCount = 0;
+			foreach (var unit in units)
+			{
+				if (unit == null)
+					continue;
+
+				foreach (var ab in unit.TraitsImplementing<AttackBase>())
+				{
+					if (ab.IsTraitDisabled || ab.IsTraitPaused)
+						continue;
+
+					foreach (var a in ab.Armaments)
+					{
+						if (a.Weapon.IsValidTarget(AirTargetTypes))
+						{
+							if (unit.Info.HasTraitInfo<AircraftInfo>())
+								missileUnitsCount += 1;
+							else
+								missileUnitsCount += 3;
+							break;
+						}
+					}
+				}
+			}
+
+			return missileUnitsCount;
+		}
+
+		protected static Actor FindDefenselessTarget(SquadRV owner)
+		{
+			Actor target = null;
+			FindSafePlace(owner, out target, true);
+
+			if (target != null)
+				foreach (var a in owner.Units)
+					if (CanAttackTarget(a, target))
+						return target;
+
+			return null;
+		}
+
+		protected static CPos? FindSafePlace(SquadRV owner, out Actor detectedEnemyTarget, bool needTarget)
+		{
+			var map = owner.World.Map;
+			var dangerRadius = owner.SquadManager.Info.DangerScanRadius;
+			detectedEnemyTarget = null;
+
+			var columnCount = (map.MapSize.X + dangerRadius - 1) / dangerRadius;
+			var rowCount = (map.MapSize.Y + dangerRadius - 1) / dangerRadius;
+			var checkIndices = Exts.MakeArray(columnCount * rowCount, i => i).Shuffle(owner.World.LocalRandom);
+			foreach (var i in checkIndices)
+			{
+				var pos = new CPos((i % columnCount) * dangerRadius, (i / columnCount) * dangerRadius);
+				if (NearToPosSafely(owner, map.CenterOfCell(pos), out detectedEnemyTarget))
+				{
+					if (needTarget && detectedEnemyTarget == null)
+						continue;
+
+					return pos;
+				}
+			}
+
+			return null;
+		}
+
+		protected static bool NearToPosSafely(SquadRV owner, WPos loc)
+		{
+			Actor a;
+			return NearToPosSafely(owner, loc, out a);
+		}
+
+		protected static bool NearToPosSafely(SquadRV owner, WPos loc, out Actor detectedEnemyTarget)
+		{
+			detectedEnemyTarget = null;
+			var dangerRadius = owner.SquadManager.Info.DangerScanRadius;
+			var unitsAroundPos = owner.World.FindActorsInCircle(loc, WDist.FromCells(dangerRadius))
+				.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a)).ToList();
+
+			if (!unitsAroundPos.Any())
+				return true;
+
+			if (CountAntiAirUnits(unitsAroundPos) < owner.Units.Count)
+			{
+				detectedEnemyTarget = unitsAroundPos.Random(owner.Random);
+				return true;
+			}
+
+			return false;
+		}
+
+		// Checks the number of anti air enemies around units
+		protected virtual bool ShouldFlee(SquadRV owner)
+		{
+			return ShouldFlee(owner, enemies => CountAntiAirUnits(enemies) > owner.Units.Count);
+		}
+	}
+
+	class AirIdleStateRV : AirStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (ShouldFlee(owner))
+			{
+				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeStateRV(), true);
+				return;
+			}
+
+			var e = FindDefenselessTarget(owner);
+			if (e == null)
+			{
+				Retreat(owner, false, true, true);
+				return;
+			}
+
+			owner.TargetActor = e;
+			owner.FuzzyStateMachine.ChangeState(owner, new AirAttackStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class AirAttackStateRV : AirStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				var a = owner.Units.Random(owner.Random);
+				var closestEnemy = owner.SquadManager.FindClosestEnemy(a.CenterPosition);
+				if (closestEnemy != null)
+					owner.TargetActor = closestEnemy;
+				else
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new AirFleeStateRV(), true);
+					return;
+				}
+			}
+
+			var teamLeader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+
+			var unitsAroundPos = owner.World.FindActorsInCircle(teamLeader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.DangerScanRadius))
+				.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a));
+			var ambushed = CountAntiAirUnits(unitsAroundPos) > owner.Units.Count;
+
+			if ((!NearToPosSafely(owner, owner.TargetActor.CenterPosition)) || ambushed)
+			{
+				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeStateRV(), true);
+				return;
+			}
+
+			foreach (var a in owner.Units)
+			{
+				if (BusyAttack(a))
+					continue;
+
+				var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
+				if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()))
+				{
+					if (IsRearming(a))
+						continue;
+
+					if (!HasAmmo(ammoPools))
+					{
+						owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+						continue;
+					}
+				}
+
+				if (CanAttackTarget(a, owner.TargetActor))
+					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+				else
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+			}
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class AirFleeStateRV : AirStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			Retreat(owner, true, true, true);
+
+			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/GroundStatesRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/GroundStatesRV.cs
@@ -1,0 +1,285 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	abstract class GroundStateBaseRV : StateBaseRV
+	{
+		protected virtual bool ShouldFlee(SquadRV owner)
+		{
+			return ShouldFlee(owner, enemies => !AttackOrFleeFuzzyRV.Default.CanAttack(owner.Units, enemies));
+		}
+
+		protected Actor FindClosestEnemy(SquadRV owner)
+		{
+			return owner.SquadManager.FindClosestEnemy(owner.Units.First().CenterPosition);
+		}
+
+		protected Actor GetRandomValuableTarget(SquadRV owner)
+		{
+			var manager = owner.SquadManager;
+			var mustDestroyedEnemy = manager.World.ActorsHavingTrait<MustBeDestroyed>(t => t.Info.RequiredForShortGame)
+					.Where(a => manager.IsPreferredEnemyUnit(a) && manager.IsNotHiddenUnit(a)).ToArray();
+
+			if (!mustDestroyedEnemy.Any())
+				return FindClosestEnemy(owner);
+
+			return mustDestroyedEnemy.Random(owner.World.LocalRandom);
+		}
+
+		protected Actor ThreatScan(SquadRV owner, Actor teamLeader, WDist scanRadius)
+		{
+			var enemies = owner.World.FindActorsInCircle(teamLeader.CenterPosition, scanRadius)
+					.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a));
+			return enemies.ClosestTo(teamLeader.CenterPosition);
+		}
+	}
+
+	class GroundUnitsIdleStateRV : GroundStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				var closestEnemy = FindClosestEnemy(owner);
+				if (closestEnemy == null)
+					return;
+
+				owner.TargetActor = closestEnemy;
+			}
+
+			var enemyUnits = owner.World.FindActorsInCircle(owner.TargetActor.CenterPosition, WDist.FromCells(owner.SquadManager.Info.IdleScanRadius))
+				.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a)).ToList();
+
+			if (enemyUnits.Count == 0)
+			{
+				Retreat(owner, false, true, true);
+				return;
+			}
+
+			if (AttackOrFleeFuzzyRV.Default.CanAttack(owner.Units, enemyUnits))
+			{
+				// We have gathered sufficient units. Attack the nearest enemy unit.
+				// Inform human allies about AI's rush attack.
+				owner.Bot.QueueOrder(new Order("PlaceBeacon", owner.SquadManager.Player.PlayerActor, Target.FromCell(owner.World, owner.TargetActor.Location), false)
+				{ SuppressVisualFeedback = true });
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveStateRV(), true);
+			}
+			else
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class GroundUnitsAttackMoveStateRV : GroundStateBaseRV, IState
+	{
+		public const int StuckInPathCheckTimes = 6;
+		public const int MakeWayTick = 2;
+
+		internal Actor PathGuider = null;
+
+		// Give tolerance for AI grouping team at start
+		internal int StuckInPath = StuckInPathCheckTimes;
+		internal int TryMakeWay = MakeWayTick;
+		internal WPos LastPos = new WPos(0, 0, 0);
+		internal int LastPosIndex = 0;
+
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			// Basic check
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				var randomSuitableEnemy = GetRandomValuableTarget(owner);
+				if (randomSuitableEnemy != null)
+					owner.TargetActor = randomSuitableEnemy;
+				else
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeStateRV(), true);
+					return;
+				}
+			}
+
+			// Initialize PathGuider. Optimaze pathfinding by using PathGuider.
+			PathGuider = owner.Units.FirstOrDefault();
+			if (PathGuider == null)
+				return;
+
+			// 1. Threat scan surroundings
+			var attackScanRadius = WDist.FromCells(owner.SquadManager.Info.AttackScanRadius);
+
+			var targetActor = ThreatScan(owner, PathGuider, attackScanRadius);
+			if (targetActor != null)
+			{
+				owner.TargetActor = targetActor;
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackStateRV(), true);
+				return;
+			}
+
+			// 2. Force scattered for navigator if needed
+			if (StuckInPath <= 0)
+			{
+				if (TryMakeWay > 0)
+				{
+					owner.Bot.QueueOrder(new Order("AttackMove", PathGuider, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+
+					foreach (var a in owner.Units)
+					{
+						if (a != PathGuider)
+							owner.Bot.QueueOrder(new Order("Scatter", a, false));
+					}
+
+					TryMakeWay--;
+				}
+				else
+				{
+					// When going through is over, restore the check
+					StuckInPath = StuckInPathCheckTimes + MakeWayTick;
+					TryMakeWay = MakeWayTick;
+				}
+
+				return;
+			}
+
+			// 3. Check if the squad is stucked due to the map has very twisted path
+			// or currently bridge and tunnel from TS mod
+			if ((PathGuider.CenterPosition - LastPos).LengthSquared <= 4)
+				StuckInPath--;
+			else
+				StuckInPath = StuckInPathCheckTimes;
+
+			LastPos = PathGuider.CenterPosition;
+
+			// 4. Since units have different movement speeds, they get separated while approaching the target.
+
+			/* Let them regroup into tighter formation towards "PathGuider".
+			 *
+			 * "unitsArea" means the space the squad units will occupy (if 1 per Cell).
+			 * PathGuider only stop when scope of "unitsAround" is not covered all units;
+			 * units in "unitsHurryUp"  will catch up,
+			 * which keep the team tight while not stucked.
+			 *
+			 * Imagining "unitsArea" takes up a a place shape like square, we need to draw a circle
+			 * to cover the the enitire circle.
+			 *
+			 * When look around, PathGuider find units around to decide if it need to continue.
+			 * and units that need hurry up will try catch up before guider waiting
+			 *
+			 * However in practice because of the poor PF, squad tend to PF to a eclipse.
+			 * "lookAround" now has the radius of two times of the circle mentioned before.
+			 */
+
+			var groupArea = (long)WDist.FromCells(owner.Units.Count).Length * 1024;
+
+			var unitsHurryUp = owner.Units.Where(a => (a.CenterPosition - PathGuider.CenterPosition).LengthSquared >= groupArea * 2).ToArray();
+			var lookAround = owner.Units.Where(a => (a.CenterPosition - PathGuider.CenterPosition).LengthSquared <= groupArea * 5).ToArray();
+
+			if (owner.Units.Count > lookAround.Length)
+				owner.Bot.QueueOrder(new Order("Stop", PathGuider, false));
+			else
+				owner.Bot.QueueOrder(new Order("AttackMove", PathGuider, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+
+			foreach (var unit in unitsHurryUp)
+				owner.Bot.QueueOrder(new Order("AttackMove", unit, Target.FromCell(owner.World, PathGuider.Location), false));
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class GroundUnitsAttackStateRV : GroundStateBaseRV, IState
+	{
+		internal Actor TeamLeader = null;
+
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			var cannotRetaliate = false;
+
+			// Basic check
+			if (!owner.IsValid)
+				return;
+
+			TeamLeader = owner.Units.FirstOrDefault();
+			if (TeamLeader == null)
+				return;
+
+			// Rescan target to prevent being ambushed and die without fight
+			// If there is no threat around, return to AttackMove state for formation
+			var attackScanRadius = WDist.FromCells(owner.SquadManager.Info.AttackScanRadius);
+			var targetActor = ThreatScan(owner, TeamLeader, attackScanRadius);
+
+			if (targetActor == null)
+			{
+				owner.TargetActor = GetRandomValuableTarget(owner);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveStateRV(), true);
+				return;
+			}
+			else
+			{
+				cannotRetaliate = true;
+				owner.TargetActor = targetActor;
+
+				foreach (var a in owner.Units)
+				{
+					if (!BusyAttack(a))
+					{
+						if (CanAttackTarget(a, targetActor))
+						{
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+							cannotRetaliate = false;
+						}
+						else
+							owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, TeamLeader.Location), false));
+					}
+					else
+						cannotRetaliate = false;
+				}
+			}
+
+			if (ShouldFlee(owner) || cannotRetaliate)
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class GroundUnitsFleeStateRV : GroundStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			Retreat(owner, true, true, true);
+
+			owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { owner.Units.Clear(); }
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/NavyStatesRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/NavyStatesRV.cs
@@ -1,0 +1,205 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	abstract class NavyStateBaseRV : StateBaseRV
+	{
+		protected virtual bool ShouldFlee(SquadRV owner)
+		{
+			return ShouldFlee(owner, enemies => !AttackOrFleeFuzzyRV.Default.CanAttack(owner.Units, enemies));
+		}
+
+		protected Actor FindClosestEnemy(SquadRV owner)
+		{
+			var first = owner.Units.First();
+
+			// Navy squad AI can exploit enemy naval production to find path, if any.
+			// (Way better than finding a nearest target which is likely to be on Ground)
+			// You might be tempted to move these lookups into Activate() but that causes null reference exception.
+			var domainIndex = first.World.WorldActor.Trait<DomainIndex>();
+			var locomotorInfo = first.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+
+			var navalProductions = owner.World.ActorsHavingTrait<Building>().Where(a
+				=> owner.SquadManager.Info.NavalProductionTypes.Contains(a.Info.Name)
+				&& domainIndex.IsPassable(first.Location, a.Location, locomotorInfo)
+				&& a.AppearsHostileTo(first));
+
+			if (navalProductions.Any())
+			{
+				var nearest = navalProductions.ClosestTo(first);
+
+				// Return nearest when it is FAR enough.
+				// If the naval production is within MaxBaseRadius, it implies that
+				// this squad is close to enemy territory and they should expect a naval combat;
+				// closest enemy makes more sense in that case.
+				if ((nearest.Location - first.Location).LengthSquared > owner.SquadManager.Info.MaxBaseRadius * owner.SquadManager.Info.MaxBaseRadius)
+					return nearest;
+			}
+
+			return owner.SquadManager.FindClosestEnemy(first.CenterPosition);
+		}
+	}
+
+	class NavyUnitsIdleStateRV : NavyStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				var closestEnemy = FindClosestEnemy(owner);
+				if (closestEnemy == null)
+					return;
+
+				owner.TargetActor = closestEnemy;
+			}
+
+			var enemyUnits = owner.World.FindActorsInCircle(owner.TargetActor.CenterPosition, WDist.FromCells(owner.SquadManager.Info.IdleScanRadius))
+				.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a)).ToList();
+
+			if (enemyUnits.Count == 0)
+			{
+				Retreat(owner, false, true, true);
+				return;
+			}
+
+			if (AttackOrFleeFuzzyRV.Default.CanAttack(owner.Units, enemyUnits))
+			{
+				foreach (var u in owner.Units)
+					owner.Bot.QueueOrder(new Order("AttackMove", u, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+
+				// We have gathered sufficient units. Attack the nearest enemy unit.
+				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsAttackMoveStateRV(), true);
+			}
+			else
+				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class NavyUnitsAttackMoveStateRV : NavyStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				var closestEnemy = FindClosestEnemy(owner);
+				if (closestEnemy != null)
+					owner.TargetActor = closestEnemy;
+				else
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeStateRV(), true);
+					return;
+				}
+			}
+
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			if (leader == null)
+				return;
+
+			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.Units.Count) / 3)
+				.Where(a => a.Owner == owner.Units.First().Owner && owner.Units.Contains(a)).ToHashSet();
+
+			if (ownUnits.Count < owner.Units.Count)
+			{
+				// Since units have different movement speeds, they get separated while approaching the target.
+				// Let them regroup into tighter formation.
+				owner.Bot.QueueOrder(new Order("Stop", leader, false));
+				foreach (var unit in owner.Units.Where(a => !ownUnits.Contains(a)))
+					owner.Bot.QueueOrder(new Order("AttackMove", unit, Target.FromCell(owner.World, leader.Location), false));
+			}
+			else
+			{
+				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.AttackScanRadius))
+					.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a));
+				var target = enemies.ClosestTo(leader.CenterPosition);
+				if (target != null)
+				{
+					owner.TargetActor = target;
+					owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsAttackStateRV(), true);
+				}
+				else
+					foreach (var a in owner.Units)
+						owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+			}
+
+			if (ShouldFlee(owner))
+				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class NavyUnitsAttackStateRV : NavyStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				var closestEnemy = FindClosestEnemy(owner);
+				if (closestEnemy != null)
+					owner.TargetActor = closestEnemy;
+				else
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeStateRV(), true);
+					return;
+				}
+			}
+
+			foreach (var a in owner.Units)
+				if (!BusyAttack(a))
+					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+
+			if (ShouldFlee(owner))
+				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class NavyUnitsFleeStateRV : NavyStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			Retreat(owner, true, true, true);
+			owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsIdleStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { owner.Units.Clear(); }
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/ProtectionStatesRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/ProtectionStatesRV.cs
@@ -1,0 +1,168 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	abstract class ProtectionStateBaseRV : GroundStateBaseRV
+	{
+	}
+
+	class UnitsForProtectionIdleStateRV : ProtectionStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				owner.TargetActor = owner.SquadManager.FindClosestEnemy(owner.CenterPosition, WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius));
+
+				if (owner.TargetActor == null)
+				{
+					Retreat(owner, false, true, true);
+					return;
+				}
+			}
+
+			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class UnitsForProtectionAttackStateRV : ProtectionStateBaseRV, IState
+	{
+		public const int BackoffTicks = 4;
+		internal int Backoff = BackoffTicks;
+
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				owner.TargetActor = owner.SquadManager.FindClosestEnemy(owner.CenterPosition, WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius));
+
+				if (owner.TargetActor == null)
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeStateRV(), true);
+					return;
+				}
+			}
+
+			// rescan target to prevent being ambushed and die without fight
+			var teamLeader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			if (teamLeader == null)
+				return;
+			var teamTail = owner.Units.MaxByOrDefault(a => (a.CenterPosition - owner.TargetActor.CenterPosition).LengthSquared);
+			var protectionScanRadius = WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius);
+			var targetActor = ThreatScan(owner, teamLeader, protectionScanRadius) ?? ThreatScan(owner, teamTail, protectionScanRadius);
+			var cannotRetaliate = false;
+
+			if (targetActor != null)
+				owner.TargetActor = targetActor;
+
+			if (!owner.IsTargetVisible)
+			{
+				if (Backoff < 0)
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeStateRV(), true);
+					Backoff = BackoffTicks;
+					return;
+				}
+
+				Backoff--;
+			}
+			else
+			{
+				cannotRetaliate = true;
+
+				foreach (var a in owner.Units)
+				{
+					// Air units control:
+					var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
+					if (a.Info.HasTraitInfo<AircraftInfo>() && ammoPools.Any())
+					{
+						if (BusyAttack(a))
+						{
+							cannotRetaliate = false;
+							continue;
+						}
+
+						if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()))
+						{
+							if (IsRearming(a))
+								continue;
+
+							if (!HasAmmo(ammoPools))
+							{
+								owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+								continue;
+							}
+						}
+
+						if (CanAttackTarget(a, owner.TargetActor))
+						{
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+							cannotRetaliate = false;
+						}
+						else
+							owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, teamLeader.Location), false));
+					}
+
+					// Ground/naval units control:
+					else
+					{
+						if (CanAttackTarget(a, owner.TargetActor))
+						{
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+							cannotRetaliate = false;
+						}
+						else
+							owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, teamLeader.Location), false));
+					}
+				}
+			}
+
+			if (cannotRetaliate)
+				owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { }
+	}
+
+	class UnitsForProtectionFleeStateRV : ProtectionStateBaseRV, IState
+	{
+		public void Activate(SquadRV owner) { }
+
+		public void Tick(SquadRV owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			Retreat(owner, true, true, true);
+
+			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionIdleStateRV(), true);
+		}
+
+		public void Deactivate(SquadRV owner) { owner.Units.Clear(); }
+	}
+}

--- a/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/StateBaseRV.cs
+++ b/OpenRA.Mods.RA2/Traits/BotModules/Squads/States/StateBaseRV.cs
@@ -1,0 +1,230 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RV.Traits.BotModules.Squads
+{
+	abstract class StateBaseRV
+	{
+		protected static void GoToRandomOwnBuilding(SquadRV squad)
+		{
+			var loc = RandomBuildingLocation(squad);
+			foreach (var a in squad.Units)
+				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+		}
+
+		protected static CPos RandomBuildingLocation(SquadRV squad)
+		{
+			var location = squad.SquadManager.GetRandomBaseCenter();
+			var buildings = squad.World.ActorsHavingTrait<Building>()
+				.Where(a => a.Owner == squad.Bot.Player).ToList();
+			if (buildings.Count > 0)
+				location = buildings.Random(squad.Random).Location;
+
+			return location;
+		}
+
+		protected static bool BusyAttack(Actor a)
+		{
+			if (a.IsIdle)
+				return false;
+
+			var activity = a.CurrentActivity;
+			var type = activity.GetType();
+			if (type == typeof(Attack) || type == typeof(FlyAttack))
+				return true;
+
+			var next = activity.NextActivity;
+			if (next == null)
+				return false;
+
+			var nextType = next.GetType();
+			if (nextType == typeof(Attack) || nextType == typeof(FlyAttack))
+				return true;
+
+			return false;
+		}
+
+		protected static bool CanAttackTarget(Actor a, Actor target)
+		{
+			if (!a.Info.HasTraitInfo<AttackBaseInfo>())
+				return false;
+
+			var targetTypes = target.GetEnabledTargetTypes();
+			if (targetTypes.IsEmpty)
+				return false;
+
+			var arms = a.TraitsImplementing<Armament>();
+			foreach (var arm in arms)
+			{
+				if (arm.IsTraitDisabled)
+					continue;
+
+				if (arm.Weapon.IsValidTarget(targetTypes))
+					return true;
+			}
+
+			return false;
+		}
+
+		protected virtual bool ShouldFlee(SquadRV squad, Func<IEnumerable<Actor>, bool> flee)
+		{
+			if (!squad.IsValid)
+				return false;
+
+			var randomSquadUnit = squad.Units.Random(squad.Random);
+			var dangerRadius = squad.SquadManager.Info.DangerScanRadius;
+			var units = squad.World.FindActorsInCircle(randomSquadUnit.CenterPosition, WDist.FromCells(dangerRadius)).ToList();
+
+			// If there are any own buildings within the DangerRadius, don't flee
+			// PERF: Avoid LINQ
+			foreach (var u in units)
+				if (u.Owner == squad.Bot.Player && u.Info.HasTraitInfo<BuildingInfo>())
+					return false;
+
+			var enemyAroundUnit = units.Where(unit => squad.SquadManager.IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>());
+			if (!enemyAroundUnit.Any())
+				return false;
+
+			return flee(enemyAroundUnit);
+		}
+
+		protected static bool IsRearming(Actor a)
+		{
+			if (a.IsIdle)
+				return false;
+
+			var activity = a.CurrentActivity;
+			if (activity.GetType() == typeof(Resupply))
+				return true;
+
+			var next = activity.NextActivity;
+			if (next == null)
+				return false;
+
+			if (next.GetType() == typeof(Resupply))
+				return true;
+
+			return false;
+		}
+
+		protected static bool FullAmmo(IEnumerable<AmmoPool> ammoPools)
+		{
+			foreach (var ap in ammoPools)
+				if (!ap.HasFullAmmo)
+					return false;
+
+			return true;
+		}
+
+		protected static bool HasAmmo(IEnumerable<AmmoPool> ammoPools)
+		{
+			foreach (var ap in ammoPools)
+				if (!ap.HasAmmo)
+					return false;
+
+			return true;
+		}
+
+		protected static bool ReloadsAutomatically(IEnumerable<AmmoPool> ammoPools, Rearmable rearmable)
+		{
+			if (rearmable == null)
+				return true;
+
+			foreach (var ap in ammoPools)
+				if (!rearmable.Info.AmmoPools.Contains(ap.Info.Name))
+					return false;
+
+			return true;
+		}
+
+		// Retreat units from combat, or for supply only in idle
+		protected void Retreat(SquadRV squad, bool flee, bool rearm, bool repair)
+		{
+			var loc = new CPos(0, 0, 0);
+
+			// HACK: "alreadyRepair" is to solve repairpad performance
+			// if repairpad logic is better we will only need
+			// this function for all flee states.
+			var alreadyRepair = false;
+
+			if (flee)
+				loc = RandomBuildingLocation(squad);
+
+			foreach (var a in squad.Units)
+			{
+				if (IsRearming(a))
+					continue;
+
+				var orderQueued = false;
+
+				// Try rearm units.
+				if (rearm)
+				{
+					var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
+					if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()) && !FullAmmo(ammoPools))
+					{
+						squad.Bot.QueueOrder(new Order("ReturnToBase", a, orderQueued));
+						orderQueued = true;
+					}
+				}
+
+				// Try repair units.
+				if (repair && !alreadyRepair)
+				{
+					Actor repairBuilding = null;
+					var orderId = "Repair";
+					var health = a.TraitOrDefault<IHealth>();
+
+					if (health != null && health.DamageState > DamageState.Undamaged)
+					{
+						var repairable = a.TraitOrDefault<Repairable>();
+						if (repairable != null)
+							repairBuilding = repairable.FindRepairBuilding(a);
+
+						/*
+						 * Don't need this in SP
+						 * and this trait class is not public
+						 *
+						else
+						{
+							var repairableNear = a.TraitOrDefault<RepairableNearSP>();
+							if (repairableNear != null)
+							{
+								orderId = "RepairNear";
+								repairBuilding = repairableNear.FindRepairBuilding(a);
+							}
+						}
+						*
+						*/
+
+						if (repairBuilding != null)
+						{
+							squad.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), orderQueued));
+							orderQueued = true;
+							alreadyRepair = true;
+						}
+					}
+				}
+
+				// If there is no order in queue and units should flee, try flee.
+				if (flee && !orderQueued)
+					squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+			}
+		}
+	}
+}

--- a/mods/rv/rules/ai.yaml
+++ b/mods/rv/rules/ai.yaml
@@ -485,9 +485,9 @@ Player:
 			gaweap: 3
 			naweap: 3
 			yaweap: 3
-			# gadept: 1
-			# nadept: 1
-			# yadept: 1
+			gadept: 1
+			nadept: 1
+			yadept: 1
 			gaairc: 1
 			# naheli: 1
 			yadisk: 1
@@ -519,9 +519,9 @@ Player:
 			gaweap: 20
 			naweap: 20
 			yaweap: 20
-			# gadept: 1
-			# nadept: 1
-			# yadept: 1
+			gadept: 1
+			nadept: 1
+			yadept: 1
 			gaairc: 10
 			# naheli: 10
 			yadisk: 10
@@ -577,9 +577,9 @@ Player:
 			gaweap: 3
 			naweap: 3
 			yaweap: 3
-			# gadept: 1
-			# nadept: 1
-			# yadept: 1
+			gadept: 1
+			nadept: 1
+			yadept: 1
 			gaairc: 1
 			# naheli: 1
 			yadisk: 1
@@ -607,9 +607,9 @@ Player:
 			gaweap: 20
 			naweap: 20
 			yaweap: 20
-			# gadept: 1
-			# nadept: 1
-			# yadept: 1
+			gadept: 1
+			nadept: 1
+			yadept: 1
 			gaairc: 10
 			# naheli: 10
 			yadisk: 10
@@ -657,11 +657,13 @@ Player:
 		HarvesterTypes: cmin, harv, gmin
 	BuildingRepairBotModule@test:
 		RequiresCondition: enable-test-ai
-	SquadManagerBotModule@test:
+	SquadManagerBotModuleRV@test:
 		RequiresCondition: enable-test-ai
-		SquadSize: 5
+		SquadSize: 15
 		RushAttackScanRadius: 30
 		ProtectUnitScanRadius: 25
+		RushInterval : 4000
+		MinimumAttackForceDelay: 2500
 		ExcludeFromSquadsTypes: cmin, harv, gmin, slav, bpln, dog, amcv, smcv, ymcv, gadock, mine, engineer
 		NavalUnitsTypes: dest, aegis, dlph, carrier, sub, hyd, sqd, dred, yhvr, gatsub, bsub
 		ConstructionYardTypes: gacnst, nacnst, yacnst
@@ -733,6 +735,7 @@ Player:
 			txdx: 1
 			disk: 2
 			magnedisk: 1
+			engineer: 1
 			commanders_power.gun_turret: 1
 			commanders_power.harrier_training: 1
 			commanders_power.inf_training: 1
@@ -753,6 +756,9 @@ Player:
 			commanders_power.cruiser_strike: 1
 			commanders_power.v3_strorm: 1
 			commanders_power.orbital_drop: 1
+		UnitLimits:
+			dog: 4
+			engineer: 1
 	UnitBuilderBotModule@test-megawealth:
 		RequiresCondition: enable-test-ai && megawealth
 		UnitQueues: Infantry.Allies, Infantry.USA, Infantry.UK, Infantry.Soviets, Infantry.Cuba, Infantry.Iraq, Infantry.Yuri, Infantry.Moon, Infantry.Baku, Vehicle.Allies, Vehicle.Germany, Vehicle.Soviets, Vehicle.USSR, Vehicle.Libya, Vehicle.Yuri, Vehicle.Psi, Vehicle.Trans, Vehicle.Baku, Aircraft.Allies, Aircraft.Korea, Aircraft.Soviets, Aircraft.Vietnam, Aircraft.Yuri, Aircraft.Lazarus, Ship.Allies, Ship.Soviets, Ship.Yuri, Power.Allies, Power.Soviets, Power.Yuri
@@ -849,3 +855,5 @@ Player:
 		CapturingActorTypes: engineer
 		CapturableActorTypes: caoild, caairp, capowr, caoutp, cahosp, cathosp, camach, caslab, capsyb, camisl, cacomm, caarmr, carpad
 		MinimumCaptureDelay: 125
+	PowerDownBotModuleRV:
+		RequiresCondition: enable-test-ai


### PR DESCRIPTION
- AI units will receive repair order when retreat. 

- AI units will give beacon to allies when ground rush. 

- AI will turn on/off buildings depending on power

- AI Ground state:
1. AttackMove State: it is optimized and take new method on reaching enemy and regrouping, which fix bug that in some SP/TS/RA2/RV map, AI ground force will stuck and take a lot of resource on pathfinding and lag the game while cannot make any progress.

2. Attack State: When there is target which is more close to team leader, entire team will switch target to prevent ambush. When there is no visible target in range, Attack State will switch back to AttackMove State.

- AI Air State:
AI aircrafts will scan threat around team leader and try retreat when get ambushed. 

- AI Protection State:
Give some of Air State logic for air units in protection team. 

Other: 
make AI squad size bigger.
enable engineer for normal gameplay.

Note:
If you are going to enable the naval units repair, you need to change in the engine to make "RepairNear"  public and then change the "StateBaseRV"